### PR TITLE
need to export LogInstance::getInstance - note has no effect on linux…

### DIFF
--- a/include/LogItInstance.h
+++ b/include/LogItInstance.h
@@ -40,7 +40,7 @@ private:
 
 public:
 	static bool instanceExists();
-	static LogItInstance* getInstance();
+	SHARED_LIB_EXPORT_DEFN static LogItInstance* getInstance();
 	static bool setInstance(LogItInstance* remoteInstance);
 	static LogItInstance* createInstance();
 


### PR DESCRIPTION
…, macro expansion empty