### PR TITLE
change errant '.' with an ISO standard ':'

### DIFF
--- a/src/LogRecord.cpp
+++ b/src/LogRecord.cpp
@@ -38,7 +38,7 @@ using boost::posix_time::microsec_clock;
 
 using std::string;
 
-const string g_sTimestampFormat = "%Y-%m-%d %H:%M.%s";
+const string g_sTimestampFormat = "%Y-%m-%d %H:%M:%s";
 
 LogRecord::LogRecord(const string& file, const int& line, const Log::LOG_LEVEL& level)
 {


### PR DESCRIPTION
Fix for OPCUA-2731 - to make the LogIt timestamp separators ISO standard complaint